### PR TITLE
build libcuml 21.12

### DIFF
--- a/.github/workflows/cuml.yml
+++ b/.github/workflows/cuml.yml
@@ -10,8 +10,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cuda: ['11.4.2', '11.2.1']
-        cuml: ['21.08']
+        # cuda: ['11.4.2', '11.2.1']
+        cuda: ['11.2.1']  # TODO: 11.4.2
+        cuml: ['21.08', '21.12']
 
     runs-on: self-hosted
     container:
@@ -81,6 +82,12 @@ jobs:
         env:
           CXXFLAGS: "-Wno-sign-compare"
         run: |
+          find "${CUML_HOME}/cpp" \
+            -type f \
+            -name ConfigureCUDA\.cmake \
+            -exec sed -E -i -e s/'-Werror([,\ ]|=[A-Za-z\-]+)?'/''/g \
+            '{}' \;
+
           mkdir -p "${CUML_HOME}/cpp/build"
           cd "${CUML_HOME}/cpp/build"
           cmake .. \


### PR DESCRIPTION
I want to build a version of libcuml 21.12 just to see whether the alledged cuML / Thrust bug in https://github.com/rapidsai/cuml/issues/4167 has been fixed in v21.12.

Signed-off-by: Yitao Li <yitao@rstudio.com>